### PR TITLE
Spring security web 4.2.3 / spring core 5.0.0 - fix

### DIFF
--- a/lottery-auth/pom.xml
+++ b/lottery-auth/pom.xml
@@ -132,6 +132,11 @@
             <version>${springsecurity.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+            <version>${springsecurity.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.security.oauth</groupId>
             <artifactId>spring-security-oauth2</artifactId>
             <version>2.1.1.RELEASE</version>


### PR DESCRIPTION
Spring security web 4.2.3 contains spring-core 5.0.0 which causes a compilation error because the PasswordEncoder Bean uses spring-core 5.0.0 so we have to manually add spring-core 4.2.3 to the pom dependencies